### PR TITLE
use correct syntax to have test launched (but with errors)

### DIFF
--- a/src/test/command.test.ts
+++ b/src/test/command.test.ts
@@ -8,42 +8,42 @@ import * as sinon from 'sinon';
 const expect = chai.expect;
 chai.use(sinonChai);
 
-suite('AtlasMap/Commands', () => {
+describe('AtlasMap/Commands', () => {
 	let sandbox: sinon.SinonSandbox;
 	const errorMessage = 'ERROR MESSAGE';
 
-	setup(() => {
+	before(() => {
 		sandbox = sinon.createSandbox();
 	});
 
-	teardown(() => {
+	after(() => {
 		sandbox.restore();
 	});
 
-	suite('Open', () => {
+	describe('Open', () => {
 		let inputStub: sinon.SinonStub;
 
-		setup(() => {
+		before(() => {
 			inputStub = sandbox.stub(vscode.window, 'showInputBox');
 			inputStub.onFirstCall().returns("localhost");
 			inputStub.onSecondCall().returns("8585");
 		});
 
-		test('works with valid inputs', async () => {
+		it('works with valid inputs', async () => {
 			const result = await vscode.commands.executeCommand('atlasmap.open');
 			expect(result).null;
 		});
 	});
 
-	suite('Start', () => {
+	describe('Start', () => {
 		let inputStub: sinon.SinonStub;
 
-		setup(() => {
+		before(() => {
 			inputStub = sandbox.stub(vscode.window, 'showInputBox');
 			inputStub.onFirstCall().returns("8585");
 		});
 
-		test('works with valid inputs', async () => {
+		it('works with valid inputs', async () => {
 			const result = await vscode.commands.executeCommand('atlasmap.start');
 			expect(result).null;
 		});


### PR DESCRIPTION
at least as we are using "bdd" type, it seems that "describe", "it" and
"before" needs to be used instead of "suite", "test" and "setup"

Signed-off-by: Aurélien Pupier <apupier@redhat.com>